### PR TITLE
bes_technology_stack changed for 6 projects

### DIFF
--- a/projects/project-metadata.json
+++ b/projects/project-metadata.json
@@ -520,12 +520,7 @@
         "HTML": 21556,
         "Shell": 7652
       },
-      "tags": [
-        "A",
-        "IND-AM",
-        "COM-C",
-        "TD-U-IoT"
-      ]
+      "tags": ["A", "IND-AM", "COM-C", "TD-U-IoT"]
     },
     {
       "id": 281,
@@ -584,12 +579,7 @@
         "Makefile": 1762,
         "Batchfile": 463
       },
-      "tags": [
-        "A",
-        "IND-AM",
-        "COM-C",
-        "TD-U-IoT"
-      ]
+      "tags": ["A", "IND-AM", "COM-C", "TD-U-IoT"]
     },
     {
       "id": 222,
@@ -649,12 +639,7 @@
         "C++": 1765,
         "Clojure": 959
       },
-      "tags": [
-        "A",
-        "IND-AM",
-        "COM-C",
-        "TD-U-IoT"
-      ]
+      "tags": ["A", "IND-AM", "COM-C", "TD-U-IoT"]
     },
     {
       "id": 136,
@@ -2804,13 +2789,7 @@
         "Python": 1169,
         "Vim Snippet": 32
       },
-      "tags": [
-        "COM-C",
-        "COM-F",
-        "L&F",
-        "TD-C-S",
-        "TD-U-AI/ML"
-      ]
+      "tags": ["COM-C", "COM-F", "L&F", "TD-C-S", "TD-U-AI/ML"]
     },
     {
       "id": 232,
@@ -6990,11 +6969,7 @@
       "language": {
         "C": 2599098
       },
-      "tags": [
-        "IND-CyS",
-        "SD-NS",
-        "S"
-      ]
+      "tags": ["IND-CyS", "SD-NS", "S"]
     },
     {
       "id": 377,
@@ -7537,12 +7512,7 @@
         "Python": 59285,
         "PowerShell": 10431
       },
-      "tags": [
-        "IND-CyS",
-        "SD-DS",
-        "SD-AS",
-        "S"
-      ]
+      "tags": ["IND-CyS", "SD-DS", "SD-AS", "S"]
     },
     {
       "id": 366,
@@ -7702,10 +7672,7 @@
         "Logos": 112845,
         "Shell": 264
       },
-      "tags": [
-        "IND-CyS",
-        "S"
-      ]
+      "tags": ["IND-CyS", "S"]
     },
     {
       "id": 172,
@@ -7783,13 +7750,7 @@
         "Dockerfile": 2041,
         "Makefile": 1438
       },
-      "tags": [
-        "A",
-        "IND-CON",
-        "COM-C",
-        "TD-U-W",
-        "Tracked"
-      ]
+      "tags": ["A", "IND-CON", "COM-C", "TD-U-W", "Tracked"]
     },
     {
       "id": 407,
@@ -12040,7 +12001,378 @@
         "Dockerfile": 637
       },
       "tags": ["COM-C", "A", "IND-CyS", "TD-C-WA", "TD-U-AI/ML", "Untracked"]
+    },
+    {
+      "id": 483,
+      "bes_tracking_id": 483,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/483",
+      "name": "helm",
+      "full_name": "Be-Secure/helm",
+      "description": "The Kubernetes Package Manager",
+      "bes_technology_stack": "S",
+      "watchers_count": 0,
+      "forks_count": 1,
+      "stargazers_count": 0,
+      "size": 17307,
+      "open_issues": 0,
+      "created_at": "2021-08-05T09:52:23Z",
+      "updated_at": "2024-02-16T04:47:35Z",
+      "pushed_at": "2024-02-16T06:24:02Z",
+      "git_url": "git://github.com/Be-Secure/helm.git",
+      "clone_url": "https://github.com/Be-Secure/helm.git",
+      "html_url": "https://github.com/Be-Secure/helm",
+      "homepage": "https://helm.sh",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/helm/helm",
+        "main_bes_url": "https://github.com/Be-Secure/helm",
+        "all_projects": [
+          {
+            "id": 43723161,
+            "name": "helm/helm",
+            "url": "https://github.com/helm/helm"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 392989850,
+            "name": "Be-Secure/helm",
+            "url": "https://github.com/Be-Secure/helm"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Go": 1590015,
+        "Shell": 32945,
+        "Makefile": 7785
+      },
+      "tags": ["COM - C", "IND-ALL", "S"]
+    },
+    {
+      "id": 486,
+      "bes_tracking_id": 486,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/486",
+      "name": "TypeScript",
+      "full_name": "Be-Secure/TypeScript",
+      "description": "TypeScript is a superset of JavaScript that compiles to clean JavaScript output.",
+      "bes_technology_stack": "L&F",
+      "watchers_count": 0,
+      "forks_count": 0,
+      "stargazers_count": 0,
+      "size": 2441878,
+      "open_issues": 0,
+      "created_at": "2024-02-14T05:25:47Z",
+      "updated_at": "2024-02-16T07:59:40Z",
+      "pushed_at": "2024-02-16T08:00:16Z",
+      "git_url": "git://github.com/Be-Secure/TypeScript.git",
+      "clone_url": "https://github.com/Be-Secure/TypeScript.git",
+      "html_url": "https://github.com/Be-Secure/TypeScript",
+      "homepage": "https://www.typescriptlang.org",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/microsoft/TypeScript",
+        "main_bes_url": "https://github.com/Be-Secure/TypeScript",
+        "all_projects": [
+          {
+            "id": 20929025,
+            "name": "microsoft/TypeScript",
+            "url": "https://github.com/microsoft/TypeScript"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 757252769,
+            "name": "Be-Secure/TypeScript",
+            "url": "https://github.com/Be-Secure/TypeScript"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "TypeScript": 126037199,
+        "JavaScript": 147115,
+        "Dockerfile": 330,
+        "Shell": 265
+      },
+      "tags": ["COM - C", "IND-ALL", "L&F"]
+    },
+    {
+      "id": 485,
+      "bes_tracking_id": 485,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/485",
+      "name": "k6",
+      "full_name": "Be-Secure/k6",
+      "description": "A modern load testing tool, using Go and JavaScript - https://k6.io",
+      "bes_technology_stack": "A",
+      "watchers_count": 0,
+      "forks_count": 1,
+      "stargazers_count": 0,
+      "size": 36030,
+      "open_issues": 0,
+      "created_at": "2024-02-14T05:24:56Z",
+      "updated_at": "2024-02-15T15:01:21Z",
+      "pushed_at": "2024-02-16T07:13:52Z",
+      "git_url": "git://github.com/Be-Secure/k6.git",
+      "clone_url": "https://github.com/Be-Secure/k6.git",
+      "html_url": "https://github.com/Be-Secure/k6",
+      "homepage": "",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/grafana/k6",
+        "main_bes_url": "https://github.com/Be-Secure/k6",
+        "all_projects": [
+          {
+            "id": 54400687,
+            "name": "grafana/k6",
+            "url": "https://github.com/grafana/k6"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 757252520,
+            "name": "Be-Secure/k6",
+            "url": "https://github.com/Be-Secure/k6"
+          }
+        ]
+      },
+      "license": {
+        "key": "agpl-3.0",
+        "name": "GNU Affero General Public License v3.0",
+        "spdx_id": "AGPL-3.0",
+        "url": "https://api.github.com/licenses/agpl-3.0",
+        "node_id": "MDc6TGljZW5zZTE="
+      },
+      "language": {
+        "Go": 2943629,
+        "Python": 18724,
+        "Shell": 14285,
+        "JavaScript": 13892,
+        "Dockerfile": 2121,
+        "Makefile": 1606
+      },
+      "tags": ["COM - C", "A", "IND-ALL"]
+    },
+    {
+      "id": 484,
+      "bes_tracking_id": 484,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/484",
+      "name": "istio",
+      "full_name": "Be-Secure/istio",
+      "description": "Connect, secure, control, and observe services.",
+      "bes_technology_stack": "S",
+      "watchers_count": 0,
+      "forks_count": 1,
+      "stargazers_count": 0,
+      "size": 257492,
+      "open_issues": 0,
+      "created_at": "2024-02-15T10:15:06Z",
+      "updated_at": "2024-02-15T15:24:00Z",
+      "pushed_at": "2024-02-15T15:48:28Z",
+      "git_url": "git://github.com/Be-Secure/istio.git",
+      "clone_url": "https://github.com/Be-Secure/istio.git",
+      "html_url": "https://github.com/Be-Secure/istio",
+      "homepage": "https://istio.io",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/istio/istio",
+        "main_bes_url": "https://github.com/Be-Secure/istio",
+        "all_projects": [
+          {
+            "id": 74175805,
+            "name": "istio/istio",
+            "url": "https://github.com/istio/istio"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 757948007,
+            "name": "Be-Secure/istio",
+            "url": "https://github.com/Be-Secure/istio"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Go": 13877147,
+        "Shell": 118525,
+        "Makefile": 53693,
+        "CSS": 47647,
+        "HTML": 28430,
+        "C": 22439,
+        "Python": 12110,
+        "Smarty": 11184,
+        "Dockerfile": 1273,
+        "Java": 1080,
+        "JavaScript": 13
+      },
+      "tags": ["COM - C", "IND-ALL", "S"]
+    },
+    {
+      "id": 482,
+      "bes_tracking_id": 482,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/482",
+      "name": "jackson-core",
+      "full_name": "Be-Secure/jackson-core",
+      "description": "Core part of Jackson that defines Streaming API as well as basic shared abstractions",
+      "bes_technology_stack": "A",
+      "watchers_count": 0,
+      "forks_count": 1,
+      "stargazers_count": 0,
+      "size": 19263,
+      "open_issues": 0,
+      "created_at": "2022-11-14T04:37:51Z",
+      "updated_at": "2022-11-14T08:35:02Z",
+      "pushed_at": "2024-02-15T15:27:32Z",
+      "git_url": "git://github.com/Be-Secure/jackson-core.git",
+      "clone_url": "https://github.com/Be-Secure/jackson-core.git",
+      "html_url": "https://github.com/Be-Secure/jackson-core",
+      "homepage": "",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/FasterXML/jackson-core",
+        "main_bes_url": "https://github.com/Be-Secure/jackson-core",
+        "all_projects": [
+          {
+            "id": 3037907,
+            "name": "FasterXML/jackson-core",
+            "url": "https://github.com/FasterXML/jackson-core"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 565676520,
+            "name": "Be-Secure/jackson-core",
+            "url": "https://github.com/Be-Secure/jackson-core"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Java": 4054159,
+        "Logos": 50545,
+        "Shell": 1527
+      },
+      "tags": ["COM - C", "A", "IND-ALL"]
     }
-    
   ]
 }

--- a/projects/project-metadata.json
+++ b/projects/project-metadata.json
@@ -834,7 +834,7 @@
         "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
         "html_url": "https://github.com/Be-Secure"
       },
-      "bes_technology_stack": "S",
+      "bes_technology_stack": "DO",
       "project_repos": {
         "main_github_url": "https://github.com/Broadcom/security-analytics-export-tools",
         "main_bes_url": "https://github.com/Be-Secure/security-analytics-export-tools",
@@ -4732,7 +4732,7 @@
         "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
         "html_url": "https://github.com/Be-Secure"
       },
-      "bes_technology_stack": "S",
+      "bes_technology_stack": "DO",
       "project_repos": {
         "main_github_url": "https://github.com/codeclimate/codeclimate",
         "main_bes_url": "https://github.com/Be-Secure/codeclimate",
@@ -5114,7 +5114,7 @@
         "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
         "html_url": "https://github.com/Be-Secure"
       },
-      "bes_technology_stack": "S",
+      "bes_technology_stack": "DO",
       "project_repos": {
         "main_github_url": "https://github.com/opstrace/opstrace",
         "main_bes_url": "https://github.com/Be-Secure/opstrace",
@@ -6763,7 +6763,7 @@
       "name": "terraform-provider-luminate",
       "full_name": "Be-Secure/terraform-provider-luminate",
       "description": "Secure access cloud terraform provider",
-      "bes_technology_stack": "S",
+      "bes_technology_stack": "DO",
       "watchers_count": 0,
       "forks_count": 0,
       "stargazers_count": 0,
@@ -8447,7 +8447,7 @@
         "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
         "html_url": "https://github.com/Be-Secure"
       },
-      "bes_technology_stack": "S",
+      "bes_technology_stack": "DO",
       "project_repos": {
         "main_github_url": "https://github.com/rdkcentral/mlem",
         "main_bes_url": "https://github.com/Be-Secure/mlem",
@@ -8507,7 +8507,7 @@
         "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
         "html_url": "https://github.com/Be-Secure"
       },
-      "bes_technology_stack": "S",
+      "bes_technology_stack": "DO",
       "project_repos": {
         "main_github_url": "https://github.com/rdkcentral/dvc",
         "main_bes_url": "https://github.com/Be-Secure/dvc",

--- a/projects/project-metadata.json
+++ b/projects/project-metadata.json
@@ -75,7 +75,12 @@
         "JavaScript": 422,
         "Dockerfile": 239
       },
-      "tags": ["COM-F", "ALL", "L&F", "DO"]
+      "tags": [
+        "COM-F",
+        "ALL",
+        "L&F",
+        "DO"
+      ]
     },
     {
       "id": 471,
@@ -153,7 +158,12 @@
         "JavaScript": 3016,
         "Smarty": 560
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-DkA"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-DkA"
+      ]
     },
     {
       "id": 470,
@@ -232,7 +242,12 @@
         "Tex": 2242,
         "Javascript": 157
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 469,
@@ -312,7 +327,13 @@
         "Emacs Lisp": 420,
         "Vim Script": 309
       },
-      "tags": ["COM-C", "ALL", "DO", "TD-C-S", "TD-U-DkA"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "DO",
+        "TD-C-S",
+        "TD-U-DkA"
+      ]
     },
     {
       "id": 445,
@@ -386,7 +407,12 @@
         "JavaScript": 3895,
         "HTML": 1124
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 290,
@@ -463,7 +489,12 @@
         "Shell": 717,
         "Batchfile": 645
       },
-      "tags": ["L&F", "ALL", "COM-C", "Tracked"]
+      "tags": [
+        "L&F",
+        "ALL",
+        "COM-C",
+        "Tracked"
+      ]
     },
     {
       "id": 278,
@@ -520,7 +551,12 @@
         "HTML": 21556,
         "Shell": 7652
       },
-      "tags": ["A", "IND-AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 281,
@@ -579,7 +615,12 @@
         "Makefile": 1762,
         "Batchfile": 463
       },
-      "tags": ["A", "IND-AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 222,
@@ -639,7 +680,12 @@
         "C++": 1765,
         "Clojure": 959
       },
-      "tags": ["A", "IND-AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 136,
@@ -694,7 +740,11 @@
         "JavaScript": 3661,
         "Shell": 414
       },
-      "tags": ["ALL", "COM-C", "TD-U-W"]
+      "tags": [
+        "ALL",
+        "COM-C",
+        "TD-U-W"
+      ]
     },
     {
       "id": 94,
@@ -754,7 +804,10 @@
         "JavaScript": 2146,
         "Makefile": 1052
       },
-      "tags": ["ALL", "COM-C"]
+      "tags": [
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 86,
@@ -807,7 +860,12 @@
         "Python": 13917,
         "Go": 11557
       },
-      "tags": ["TEL", "SD-NS", "COM-C", "TD-C-CA"]
+      "tags": [
+        "TEL",
+        "SD-NS",
+        "COM-C",
+        "TD-C-CA"
+      ]
     },
     {
       "id": 84,
@@ -877,7 +935,13 @@
         "Python": 416,
         "Makefile": 198
       },
-      "tags": ["ALL", "COM-F", "TD-C-WA", "TD-C-A", "TD-U-W"]
+      "tags": [
+        "ALL",
+        "COM-F",
+        "TD-C-WA",
+        "TD-C-A",
+        "TD-U-W"
+      ]
     },
     {
       "id": 85,
@@ -941,7 +1005,13 @@
         "Mustache": 449,
         "Vim Snippet": 135
       },
-      "tags": ["ALL", "COM-F", "TD-C-Ms", "TD-U-ApD", "COM-C"]
+      "tags": [
+        "ALL",
+        "COM-F",
+        "TD-C-Ms",
+        "TD-U-ApD",
+        "COM-C"
+      ]
     },
     {
       "id": 247,
@@ -1009,7 +1079,11 @@
         "Pike": 583,
         "Ruby": 234
       },
-      "tags": ["AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 218,
@@ -1057,7 +1131,11 @@
         "Python": 68622,
         "CMake": 9556
       },
-      "tags": ["AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 252,
@@ -1110,7 +1188,11 @@
         "Python": 169319,
         "Shell": 373
       },
-      "tags": ["AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 76,
@@ -1187,7 +1269,12 @@
         "Starlark": 25499,
         "Dockerfile": 3669
       },
-      "tags": ["L&F", "ALL", "COM-C", "Tracked"]
+      "tags": [
+        "L&F",
+        "ALL",
+        "COM-C",
+        "Tracked"
+      ]
     },
     {
       "id": 274,
@@ -1244,7 +1331,11 @@
         "C++": 2915,
         "Makefile": 331
       },
-      "tags": ["AM", "COM-C", "TD-U-IoT"]
+      "tags": [
+        "AM",
+        "COM-C",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 75,
@@ -1318,7 +1409,14 @@
         "Makefile": 11998,
         "Shell": 8352
       },
-      "tags": ["L&F", "ALL", "COM-C", "TD-U-AI/ML", "TD-C-DA", "Tracked"]
+      "tags": [
+        "L&F",
+        "ALL",
+        "COM-C",
+        "TD-U-AI/ML",
+        "TD-C-DA",
+        "Tracked"
+      ]
     },
     {
       "id": 233,
@@ -1378,7 +1476,11 @@
         "GDB": 603,
         "Assembly": 47
       },
-      "tags": ["A", "IND-AM", "COM-C"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C"
+      ]
     },
     {
       "id": 74,
@@ -1453,7 +1555,13 @@
         "CMake": 25087,
         "Dockerfile": 319
       },
-      "tags": ["A", "ALL", "COM-C", "TD-U-ApD", "Tracked"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-U-ApD",
+        "Tracked"
+      ]
     },
     {
       "id": 186,
@@ -1515,7 +1623,12 @@
         "Ruby": 879,
         "Hack": 383
       },
-      "tags": ["A", "IND-ED", "COM-C", "TD-C-WA"]
+      "tags": [
+        "A",
+        "IND-ED",
+        "COM-C",
+        "TD-C-WA"
+      ]
     },
     {
       "id": 73,
@@ -1589,7 +1702,12 @@
         "HTML": 137,
         "CSS": 59
       },
-      "tags": ["A", "ALL", "COM-C", "TD-U-ApD"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-U-ApD"
+      ]
     },
     {
       "id": 139,
@@ -1660,7 +1778,12 @@
         "Prolog": 843,
         "Dockerfile": 309
       },
-      "tags": ["L&F", "COM-C", "TD-U-AI/ML", "TD-C-CA"]
+      "tags": [
+        "L&F",
+        "COM-C",
+        "TD-U-AI/ML",
+        "TD-C-CA"
+      ]
     },
     {
       "id": 72,
@@ -1737,7 +1860,12 @@
         "HTML": 137,
         "CSS": 59
       },
-      "tags": ["A", "ALL", "COM-C", "TD-U-ApD"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-U-ApD"
+      ]
     },
     {
       "id": 187,
@@ -1801,7 +1929,12 @@
         "Vim Script": 406,
         "Ruby": 220
       },
-      "tags": ["A", "ALL", "COM-C", "TD-U-DkA"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-U-DkA"
+      ]
     },
     {
       "id": 71,
@@ -1871,7 +2004,12 @@
       "language": {
         "Python": 56176
       },
-      "tags": ["L&F", "ALL", "COM-C", "TD-U-AI/ML"]
+      "tags": [
+        "L&F",
+        "ALL",
+        "COM-C",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 188,
@@ -1928,7 +2066,13 @@
         "CSS": 623503,
         "VCL": 26002
       },
-      "tags": ["A", "IND-RT", "COM-C", "TD-U-DkA", "TD-C-CA"]
+      "tags": [
+        "A",
+        "IND-RT",
+        "COM-C",
+        "TD-U-DkA",
+        "TD-C-CA"
+      ]
     },
     {
       "id": 242,
@@ -1981,7 +2125,11 @@
         "JavaScript": 754789,
         "Shell": 58
       },
-      "tags": ["L&F", "ALL", "COM-C"]
+      "tags": [
+        "L&F",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 198,
@@ -2045,7 +2193,14 @@
         "C": 419,
         "Batchfile": 140
       },
-      "tags": ["A", "ALL", "COM-C", "TD-U-W", "TD-U-DkA", "TD-U-MoA"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-U-W",
+        "TD-U-DkA",
+        "TD-U-MoA"
+      ]
     },
     {
       "id": 82,
@@ -2107,7 +2262,12 @@
         "Rust": 970,
         "Emacs Lisp": 478
       },
-      "tags": ["L&F", "SD-AS", "ALL", "COM-C"]
+      "tags": [
+        "L&F",
+        "SD-AS",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 235,
@@ -2302,7 +2462,11 @@
       "language": {
         "Python": 66777
       },
-      "tags": ["L&F", "SD-AS", "IND-CyS"]
+      "tags": [
+        "L&F",
+        "SD-AS",
+        "IND-CyS"
+      ]
     },
     {
       "id": 189,
@@ -2368,7 +2532,12 @@
         "Kotlin": 1322,
         "Makefile": 313
       },
-      "tags": ["A", "IND-ED", "COM-C", "TD-C-A"]
+      "tags": [
+        "A",
+        "IND-ED",
+        "COM-C",
+        "TD-C-A"
+      ]
     },
     {
       "id": 191,
@@ -2432,7 +2601,12 @@
         "Swift": 807,
         "Dockerfile": 112
       },
-      "tags": ["A", "ALL", "COM-C", "TD-C-A"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-C-A"
+      ]
     },
     {
       "id": 145,
@@ -2491,7 +2665,12 @@
         "EmberScript": 4202,
         "Awk": 639
       },
-      "tags": ["A", "IND-AM", "COM-C", "TD-C-A"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C",
+        "TD-C-A"
+      ]
     },
     {
       "id": 192,
@@ -2541,7 +2720,12 @@
         "node_id": "MDc6TGljZW5zZTU="
       },
       "language": {},
-      "tags": ["A", "IND-AM", "COM-C", "TD-C-A"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C",
+        "TD-C-A"
+      ]
     },
     {
       "id": 194,
@@ -2599,7 +2783,12 @@
         "HTML": 5274,
         "Shell": 4538
       },
-      "tags": ["A", "IND-AM", "COM-C", "TD-C-A"]
+      "tags": [
+        "A",
+        "IND-AM",
+        "COM-C",
+        "TD-C-A"
+      ]
     },
     {
       "id": 96,
@@ -2674,7 +2863,13 @@
         "C": 42335,
         "Makefile": 1644
       },
-      "tags": ["L&F", "IND-ED", "COM-C", "TD-U-AI/ML", "TD-C-A"]
+      "tags": [
+        "L&F",
+        "IND-ED",
+        "COM-C",
+        "TD-U-AI/ML",
+        "TD-C-A"
+      ]
     },
     {
       "id": 229,
@@ -2731,7 +2926,15 @@
         "Dockerfile": 2779,
         "Shell": 1464
       },
-      "tags": ["A", "ALL", "IND-Cys", "SD-IoTS", "SD-NS", "SD-SRM", "TD-U-DAA"]
+      "tags": [
+        "A",
+        "ALL",
+        "IND-Cys",
+        "SD-IoTS",
+        "SD-NS",
+        "SD-SRM",
+        "TD-U-DAA"
+      ]
     },
     {
       "id": 230,
@@ -2789,7 +2992,13 @@
         "Python": 1169,
         "Vim Snippet": 32
       },
-      "tags": ["COM-C", "COM-F", "L&F", "TD-C-S", "TD-U-AI/ML"]
+      "tags": [
+        "COM-C",
+        "COM-F",
+        "L&F",
+        "TD-C-S",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 232,
@@ -2846,7 +3055,13 @@
         "JavaScript": 3483,
         "PHP": 86
       },
-      "tags": ["A", "ALL", "SD-AS", "TD-C-WA", "TD-U-W"]
+      "tags": [
+        "A",
+        "ALL",
+        "SD-AS",
+        "TD-C-WA",
+        "TD-U-W"
+      ]
     },
     {
       "id": 202,
@@ -2917,7 +3132,11 @@
         "JavaScript": 754789,
         "Shell": 58
       },
-      "tags": ["L&F", "ALL", "COM-C"]
+      "tags": [
+        "L&F",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 169,
@@ -2992,7 +3211,11 @@
         "VimSnippet": 1990,
         "Shell": 337
       },
-      "tags": ["TD-U-ApD", "ALL", "COM-C"]
+      "tags": [
+        "TD-U-ApD",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 159,
@@ -3072,7 +3295,11 @@
         "HTML": 80,
         "JavaScript": 10
       },
-      "tags": ["TD-C-WA", "ALL", "COM-C"]
+      "tags": [
+        "TD-C-WA",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 161,
@@ -3148,7 +3375,11 @@
         "Shell": 1668,
         "Dockerfile": 1088
       },
-      "tags": ["TD-U-W", "ALL", "COM-C"]
+      "tags": [
+        "TD-U-W",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 171,
@@ -3221,7 +3452,11 @@
         "Dockerfile": 2169,
         "Shell": 439
       },
-      "tags": ["TD-U-W", "IND-RT", "COM-C"]
+      "tags": [
+        "TD-U-W",
+        "IND-RT",
+        "COM-C"
+      ]
     },
     {
       "id": 150,
@@ -3279,7 +3514,11 @@
         "Dockerfile": 2468,
         "Makefile": 1839
       },
-      "tags": ["A", "ALL", "COM-C"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 200,
@@ -3334,7 +3573,11 @@
         "Vue": 432140,
         "Shell": 636
       },
-      "tags": ["A", "IND-BFSI", "COM-C"]
+      "tags": [
+        "A",
+        "IND-BFSI",
+        "COM-C"
+      ]
     },
     {
       "id": 154,
@@ -3390,7 +3633,11 @@
         "Logos": 831,
         "JavaScript": 234
       },
-      "tags": ["A", "ALL", "COM-C"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 156,
@@ -3443,7 +3690,10 @@
         "PHP": 124320,
         "Shell": 2366
       },
-      "tags": ["A", "ALL"]
+      "tags": [
+        "A",
+        "ALL"
+      ]
     },
     {
       "id": 158,
@@ -3501,7 +3751,11 @@
         "CSS": 23374,
         "Dockerfile": 3250
       },
-      "tags": ["A", "ALL", "TD-U-IoT"]
+      "tags": [
+        "A",
+        "ALL",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 197,
@@ -3565,7 +3819,10 @@
         "Less": 56,
         "Sass": 13
       },
-      "tags": ["DO", "ALL"]
+      "tags": [
+        "DO",
+        "ALL"
+      ]
     },
     {
       "id": 148,
@@ -3636,7 +3893,11 @@
         "CoffeeScript": 3009,
         "Makefile": 879
       },
-      "tags": ["L&F", "IND-ED", "COM-C"]
+      "tags": [
+        "L&F",
+        "IND-ED",
+        "COM-C"
+      ]
     },
     {
       "id": 195,
@@ -3693,7 +3954,11 @@
         "CSS": 78728,
         "HTML": 2173
       },
-      "tags": ["A", "ALL", "COM-C"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 221,
@@ -3767,7 +4032,13 @@
         "Mustache": 9273,
         "Dockerfile": 2946
       },
-      "tags": ["COM-C", "A", "ALL", "TD-C-CA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "TD-C-CA",
+        "Tracked"
+      ]
     },
     {
       "id": 91,
@@ -3842,7 +4113,12 @@
         "JavaScript": 7167,
         "CSS": 1322
       },
-      "tags": ["COM-C", "A", "ALL", "Tracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "Tracked"
+      ]
     },
     {
       "id": 92,
@@ -3922,7 +4198,11 @@
         "AMPL": 11309,
         "Dockerfile": 2442
       },
-      "tags": ["A", "ALL", "Tracked"]
+      "tags": [
+        "A",
+        "ALL",
+        "Tracked"
+      ]
     },
     {
       "id": 95,
@@ -3995,7 +4275,13 @@
         "Shell": 2016,
         "Java": 1685
       },
-      "tags": ["COM-C", "DO", "ALL", "SD-AS", "Tracked"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "ALL",
+        "SD-AS",
+        "Tracked"
+      ]
     },
     {
       "id": 217,
@@ -4164,7 +4450,12 @@
         "JavaScript": 44193,
         "Dockerfile": 346
       },
-      "tags": ["s", "ALL", "COM-C", "Tracked"]
+      "tags": [
+        "s",
+        "ALL",
+        "COM-C",
+        "Tracked"
+      ]
     },
     {
       "id": 238,
@@ -4244,7 +4535,12 @@
         "AMPL": 509,
         "EmacsLisp": 73
       },
-      "tags": ["COM-C", "A", "ALL", "Tracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "Tracked"
+      ]
     },
     {
       "id": 240,
@@ -4331,7 +4627,12 @@
         "Batchfile": 1863,
         "C": 847
       },
-      "tags": ["COM-C", "ALL", "L&F", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "Tracked"
+      ]
     },
     {
       "id": 224,
@@ -4399,7 +4700,12 @@
         "Batchfile": 335,
         "Makefile": 156
       },
-      "tags": ["A", "ALL", "COM-C", "TD-U-DkA"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C",
+        "TD-U-DkA"
+      ]
     },
     {
       "id": 228,
@@ -4455,7 +4761,12 @@
         "Makefile": 1809,
         "Dockerfile": 914
       },
-      "tags": ["S", "ALL", "COM-C", "SD-AS"]
+      "tags": [
+        "S",
+        "ALL",
+        "COM-C",
+        "SD-AS"
+      ]
     },
     {
       "id": 226,
@@ -4509,7 +4820,12 @@
         "CSS": 8352,
         "JavaScript": 5720
       },
-      "tags": ["DO", "ALL", "COM-C", "TD-U-W"]
+      "tags": [
+        "DO",
+        "ALL",
+        "COM-C",
+        "TD-U-W"
+      ]
     },
     {
       "id": 80,
@@ -4578,7 +4894,13 @@
         "Rust": 280,
         "Emacs_Lisp": 191
       },
-      "tags": ["COM-F", "IND-CyS", "SD-SRM", "TD-C-WA", "S"]
+      "tags": [
+        "COM-F",
+        "IND-CyS",
+        "SD-SRM",
+        "TD-C-WA",
+        "S"
+      ]
     },
     {
       "id": 185,
@@ -4636,7 +4958,12 @@
         "Dockerfile": 2168,
         "Shell": 638
       },
-      "tags": ["S", "IND-CyS", "COM-C", "TD-C-WA"]
+      "tags": [
+        "S",
+        "IND-CyS",
+        "COM-C",
+        "TD-C-WA"
+      ]
     },
     {
       "id": 90,
@@ -4691,7 +5018,11 @@
         "Dockerfile": 11698,
         "Makefile": 6565
       },
-      "tags": ["S", "ALL", "COM-C"]
+      "tags": [
+        "S",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 275,
@@ -4751,7 +5082,12 @@
         "Perl": 3832,
         "XSLT": 3054
       },
-      "tags": ["S", "IND-CyS", "COM-C", "TD-C-WA"]
+      "tags": [
+        "S",
+        "IND-CyS",
+        "COM-C",
+        "TD-C-WA"
+      ]
     },
     {
       "id": 89,
@@ -4812,7 +5148,11 @@
         "PLpgSQL": 1235,
         "HTML": 626
       },
-      "tags": ["S", "ALL", "COM-C"]
+      "tags": [
+        "S",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 68,
@@ -4881,7 +5221,12 @@
         "Pug": 319,
         "Procfile": 45
       },
-      "tags": ["DO", "COM-F", "IND-NG", "TD-C-WA"]
+      "tags": [
+        "DO",
+        "COM-F",
+        "IND-NG",
+        "TD-C-WA"
+      ]
     },
     {
       "id": 69,
@@ -4950,7 +5295,12 @@
         "Batchfile": 1388,
         "Vue": 563
       },
-      "tags": ["A", "COM-C", "IND-HLS", "TD-U-W"]
+      "tags": [
+        "A",
+        "COM-C",
+        "IND-HLS",
+        "TD-U-W"
+      ]
     },
     {
       "id": 249,
@@ -5028,7 +5378,13 @@
         "Smarty": 7825,
         "JavaScript": 1191
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-C-CA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-C-CA",
+        "Tracked"
+      ]
     },
     {
       "id": 318,
@@ -5097,7 +5453,13 @@
         "Makefile": 4534,
         "Shell": 914
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 317,
@@ -5172,7 +5534,13 @@
         "Assembly": 22181,
         "Shell": 1241
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 319,
@@ -5249,7 +5617,11 @@
         "Batchfile": 24179,
         "SCSS": 56
       },
-      "tags": ["COM-C", "ALL", "L&F"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F"
+      ]
     },
     {
       "id": 320,
@@ -5323,7 +5695,12 @@
         "Roff": 198068,
         "CMake": 125035
       },
-      "tags": ["COM-C", "ALL", "L&F", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "Tracked"
+      ]
     },
     {
       "id": 70,
@@ -5402,7 +5779,12 @@
         "Shell": 380,
         "Dockerfile": 193
       },
-      "tags": ["COM-C", "A", "ALL", "TD-U-AI/ML"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 253,
@@ -5467,7 +5849,12 @@
         "Makefile": 1915,
         "Roff": 911
       },
-      "tags": ["A", "COM-C", "IND-HLS", "TD-U-W"]
+      "tags": [
+        "A",
+        "COM-C",
+        "IND-HLS",
+        "TD-U-W"
+      ]
     },
     {
       "id": 330,
@@ -5729,7 +6116,13 @@
         "Dockerfile": 511,
         "Shell": 495
       },
-      "tags": ["COM-C", "A", "ALL", "TD-U-ApD", "Tracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "TD-U-ApD",
+        "Tracked"
+      ]
     },
     {
       "id": 371,
@@ -5804,7 +6197,12 @@
         "C++": 753,
         "Fortran": 112
       },
-      "tags": ["COM-C", "A", "ALL", "Tracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "Tracked"
+      ]
     },
     {
       "id": 372,
@@ -5876,7 +6274,13 @@
         "CMake": 34496,
         "Python": 9887
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-C-DA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-C-DA",
+        "Tracked"
+      ]
     },
     {
       "id": 373,
@@ -5956,7 +6360,13 @@
         "Cuda": 15397,
         "Verilog": 366
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-C-CA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-C-CA",
+        "Tracked"
+      ]
     },
     {
       "id": 374,
@@ -6027,7 +6437,13 @@
         "C++": 330211,
         "CMake": 10490
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-C-DA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-C-DA",
+        "Tracked"
+      ]
     },
     {
       "id": 375,
@@ -6095,7 +6511,12 @@
         "node_id": "MDc6TGljZW5zZTA="
       },
       "language": {},
-      "tags": ["COM-C", "ALL", "L&F", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "Tracked"
+      ]
     },
     {
       "id": 376,
@@ -6170,7 +6591,12 @@
         "Makefile": 2234,
         "Shell": 2028
       },
-      "tags": ["COM-C", "ALL", "L&F", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "Tracked"
+      ]
     },
     {
       "id": 418,
@@ -6242,7 +6668,13 @@
         "Logos": 112845,
         "Shell": 264
       },
-      "tags": ["A", "TD-C-WA", "ALL", "L&F", "Tracked"]
+      "tags": [
+        "A",
+        "TD-C-WA",
+        "ALL",
+        "L&F",
+        "Tracked"
+      ]
     },
     {
       "id": 417,
@@ -6315,7 +6747,14 @@
         "SCSS": 7510,
         "JavaScript": 2871
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-C-WA", "TD-U-W", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-C-WA",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 419,
@@ -6387,7 +6826,13 @@
         "Shell": 2281,
         "Makefile": 1084
       },
-      "tags": ["COM-C", "ALL", "SD-CS", "S", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "SD-CS",
+        "S",
+        "Tracked"
+      ]
     },
     {
       "id": 88,
@@ -6445,7 +6890,11 @@
         "Batchfile": 1959,
         "Dockerfile": 1421
       },
-      "tags": ["A", "ALL", "COM-C"]
+      "tags": [
+        "A",
+        "ALL",
+        "COM-C"
+      ]
     },
     {
       "id": 119,
@@ -6514,7 +6963,13 @@
         "Makefile": 659,
         "PostScript": 5
       },
-      "tags": ["A", "ALL", "TD-C-D", "COM-C", "TD-U-Db"]
+      "tags": [
+        "A",
+        "ALL",
+        "TD-C-D",
+        "COM-C",
+        "TD-U-Db"
+      ]
     },
     {
       "id": 350,
@@ -6584,7 +7039,12 @@
       "language": {
         "Python": 1524479
       },
-      "tags": ["COM-C", "A", "ALL", "TD-U-DkA"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "TD-U-DkA"
+      ]
     },
     {
       "id": 365,
@@ -6656,7 +7116,11 @@
         "HTML": 1953,
         "CSS": 596
       },
-      "tags": ["ALL", "L&F", "SD-SRM"]
+      "tags": [
+        "ALL",
+        "L&F",
+        "SD-SRM"
+      ]
     },
     {
       "id": 363,
@@ -6731,7 +7195,13 @@
         "Makefile": 6873,
         "Dockerfile": 2539
       },
-      "tags": ["COM-C", "ALL", "TD-C-S", "SD-IAM", "S"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "TD-C-S",
+        "SD-IAM",
+        "S"
+      ]
     },
     {
       "id": 364,
@@ -6807,7 +7277,12 @@
         "TypeScript": 2933,
         "Dockerfile": 623
       },
-      "tags": ["COM-C", "ALL", "SD-IAM", "S"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "SD-IAM",
+        "S"
+      ]
     },
     {
       "id": 345,
@@ -6969,7 +7444,11 @@
       "language": {
         "C": 2599098
       },
-      "tags": ["IND-CyS", "SD-NS", "S"]
+      "tags": [
+        "IND-CyS",
+        "SD-NS",
+        "S"
+      ]
     },
     {
       "id": 377,
@@ -7049,7 +7528,12 @@
         "Mako": 412,
         "Procfile": 70
       },
-      "tags": ["COM-C", "ALL", "SD-IAM", "S"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "SD-IAM",
+        "S"
+      ]
     },
     {
       "id": 378,
@@ -7123,7 +7607,12 @@
         "Dockerfile": 2517,
         "Makefile": 1085
       },
-      "tags": ["COM-C", "IND-CyS", "SD-CS", "S"]
+      "tags": [
+        "COM-C",
+        "IND-CyS",
+        "SD-CS",
+        "S"
+      ]
     },
     {
       "id": 362,
@@ -7200,7 +7689,12 @@
         "Jsonnet": 2307,
         "Dockerfile": 299
       },
-      "tags": ["COM-C", "ALL", "SD-IAM", "S"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "SD-IAM",
+        "S"
+      ]
     },
     {
       "id": 379,
@@ -7293,7 +7787,12 @@
         "Rich Text Format": 416,
         "RouterOS Script": 45
       },
-      "tags": ["COM-C", "IND-CyS", "L&F", "SD-SOC"]
+      "tags": [
+        "COM-C",
+        "IND-CyS",
+        "L&F",
+        "SD-SOC"
+      ]
     },
     {
       "id": 380,
@@ -7366,7 +7865,12 @@
         "PowerShell": 3178,
         "Batchfile": 1223
       },
-      "tags": ["COM-F", "IND-CyS", "L&F", "SD-NS"]
+      "tags": [
+        "COM-F",
+        "IND-CyS",
+        "L&F",
+        "SD-NS"
+      ]
     },
     {
       "id": 381,
@@ -7441,7 +7945,13 @@
         "Dockerfile": 1308,
         "C": 118
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML", "TD-U-DAA"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML",
+        "TD-U-DAA"
+      ]
     },
     {
       "id": 383,
@@ -7512,7 +8022,12 @@
         "Python": 59285,
         "PowerShell": 10431
       },
-      "tags": ["IND-CyS", "SD-DS", "SD-AS", "S"]
+      "tags": [
+        "IND-CyS",
+        "SD-DS",
+        "SD-AS",
+        "S"
+      ]
     },
     {
       "id": 366,
@@ -7602,7 +8117,13 @@
         "Objective-C++": 2640,
         "AppleScript": 1932
       },
-      "tags": ["DO", "ALL", "SD-DS", "TD-C-D", "TD-U-Db"]
+      "tags": [
+        "DO",
+        "ALL",
+        "SD-DS",
+        "TD-C-D",
+        "TD-U-Db"
+      ]
     },
     {
       "id": 261,
@@ -7672,7 +8193,10 @@
         "Logos": 112845,
         "Shell": 264
       },
-      "tags": ["IND-CyS", "S"]
+      "tags": [
+        "IND-CyS",
+        "S"
+      ]
     },
     {
       "id": 172,
@@ -7750,7 +8274,13 @@
         "Dockerfile": 2041,
         "Makefile": 1438
       },
-      "tags": ["A", "IND-CON", "COM-C", "TD-U-W", "Tracked"]
+      "tags": [
+        "A",
+        "IND-CON",
+        "COM-C",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 407,
@@ -7826,7 +8356,13 @@
         "CSS": 1403,
         "Dockerfile": 1072
       },
-      "tags": ["COM-C", "IND-CyS", "SD-IAM", "S", "Untracked"]
+      "tags": [
+        "COM-C",
+        "IND-CyS",
+        "SD-IAM",
+        "S",
+        "Untracked"
+      ]
     },
     {
       "id": 432,
@@ -7878,7 +8414,13 @@
       "language": {
         "python": 235225
       },
-      "tags": ["S", "ALL", "COM-C", "TD-C-S", "TD-U-AI/ML"]
+      "tags": [
+        "S",
+        "ALL",
+        "COM-C",
+        "TD-C-S",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 433,
@@ -7933,7 +8475,12 @@
         "HCL": 1869,
         "Jupyter Notebook": 1693
       },
-      "tags": ["S", "ALL", "COM-C", "TD-U-AI/ML"]
+      "tags": [
+        "S",
+        "ALL",
+        "COM-C",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 434,
@@ -7986,7 +8533,12 @@
         "python": 2353579,
         "Shell": 216
       },
-      "tags": ["S", "ALL", "COM-C", "TD-U-AI/ML"]
+      "tags": [
+        "S",
+        "ALL",
+        "COM-C",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 435,
@@ -8222,7 +8774,13 @@
         "TypeScript": 438366,
         "HTML": 2416
       },
-      "tags": ["COM-C", "IND-AM", "A", "Tracked", "TD-U-IoT"]
+      "tags": [
+        "COM-C",
+        "IND-AM",
+        "A",
+        "Tracked",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 225,
@@ -8296,7 +8854,13 @@
         "M4": 232,
         "Shell": 62
       },
-      "tags": ["COM-C", "IND-AM", "A", "Tracked", "TD-U-IoT"]
+      "tags": [
+        "COM-C",
+        "IND-AM",
+        "A",
+        "Tracked",
+        "TD-U-IoT"
+      ]
     },
     {
       "id": 223,
@@ -8374,7 +8938,13 @@
         "Perl": 16892,
         "Dockerfile": 2765
       },
-      "tags": ["COM-F", "A", "ALL", "TD-U-W", "Tracked"]
+      "tags": [
+        "COM-F",
+        "A",
+        "ALL",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 87,
@@ -8447,7 +9017,13 @@
         "SCSS": 1563,
         "HTML": 792
       },
-      "tags": ["COM-C", "A", "ALL", "TD-C-WA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "TD-C-WA",
+        "Tracked"
+      ]
     },
     {
       "id": 437,
@@ -8602,7 +9178,14 @@
         "HTML": 3183,
         "CSS": 981
       },
-      "tags": ["COM-C", "A", "IND-CyS", "TD-C-CA", "Untracked", "TD-U-DLT/BC"]
+      "tags": [
+        "COM-C",
+        "A",
+        "IND-CyS",
+        "TD-C-CA",
+        "Untracked",
+        "TD-U-DLT/BC"
+      ]
     },
     {
       "id": 446,
@@ -8680,7 +9263,14 @@
         "MDX": 1670,
         "Dockerfile": 1571
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-C-WA", "TD-U-AI/ML", "Untracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-C-WA",
+        "TD-U-AI/ML",
+        "Untracked"
+      ]
     },
     {
       "id": 180,
@@ -8746,7 +9336,13 @@
         "Blade": 18386,
         "Shell": 899
       },
-      "tags": ["COM-F", "ALL", "L&F", "TD-U-W", "Tracked"]
+      "tags": [
+        "COM-F",
+        "ALL",
+        "L&F",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 455,
@@ -9022,7 +9618,14 @@
         "Starlark": 11590,
         "Shell": 813
       },
-      "tags": ["COM-F", "IND-CyS", "SD-AS", "S", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-F",
+        "IND-CyS",
+        "SD-AS",
+        "S",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 467,
@@ -9094,7 +9697,14 @@
         "Jupyter Notebook": 79309,
         "Makefile": 714
       },
-      "tags": ["COM-F", "IND-CyS", "SD-AS", "S", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-F",
+        "IND-CyS",
+        "SD-AS",
+        "S",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 259,
@@ -9170,7 +9780,12 @@
         "HTML": 2184,
         "HCL": 878
       },
-      "tags": ["COM-C", "IND-CyS", "S", "SD-BS"]
+      "tags": [
+        "COM-C",
+        "IND-CyS",
+        "S",
+        "SD-BS"
+      ]
     },
     {
       "id": 103,
@@ -9253,7 +9868,11 @@
         "Makefile": 8003,
         "Dockerfile": 897
       },
-      "tags": ["COM-C", "DA", "ALL"]
+      "tags": [
+        "COM-C",
+        "DA",
+        "ALL"
+      ]
     },
     {
       "id": 257,
@@ -9329,7 +9948,12 @@
         "HTML": 9852,
         "Dockerfile": 1309
       },
-      "tags": ["COM-C", "IND-CyS", "SD-BS", "S"]
+      "tags": [
+        "COM-C",
+        "IND-CyS",
+        "SD-BS",
+        "S"
+      ]
     },
     {
       "id": 447,
@@ -9401,7 +10025,12 @@
         "JavaScript": 35857,
         "Shell": 142
       },
-      "tags": ["COM-C", "IND-CyS", "SD-SOC", "S"]
+      "tags": [
+        "COM-C",
+        "IND-CyS",
+        "SD-SOC",
+        "S"
+      ]
     },
     {
       "id": 296,
@@ -9489,7 +10118,14 @@
         "Mustache": 1406,
         "PHP": 574
       },
-      "tags": ["COM-C", "DO", "ALL", "SD-SOC", "TD-U-DAA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "ALL",
+        "SD-SOC",
+        "TD-U-DAA",
+        "Tracked"
+      ]
     },
     {
       "id": 299,
@@ -9569,7 +10205,12 @@
         "CSS": 3721,
         "Dockerfile": 1270
       },
-      "tags": ["COM-F", "DO", "SD-SOC", "TD-U-DAA"]
+      "tags": [
+        "COM-F",
+        "DO",
+        "SD-SOC",
+        "TD-U-DAA"
+      ]
     },
     {
       "id": 453,
@@ -9648,7 +10289,11 @@
         "Batchfile": 833,
         "HTML": 106
       },
-      "tags": ["COM-C", "DO", "ALL"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "ALL"
+      ]
     },
     {
       "id": 130,
@@ -9725,7 +10370,12 @@
         "Makefile": 125,
         "Procfile": 47
       },
-      "tags": ["COM-C", "L&F", "ALL", "TD-U-W"]
+      "tags": [
+        "COM-C",
+        "L&F",
+        "ALL",
+        "TD-U-W"
+      ]
     },
     {
       "id": 135,
@@ -9808,7 +10458,12 @@
         "Assembly": 157,
         "Dockerfile": 33
       },
-      "tags": ["COM-C", "L&F", "ALL", "IND-CyS"]
+      "tags": [
+        "COM-C",
+        "L&F",
+        "ALL",
+        "IND-CyS"
+      ]
     },
     {
       "id": 215,
@@ -9884,7 +10539,13 @@
         "Lex": 10152,
         "AMPL": 801
       },
-      "tags": ["COM-C", "A", "ALL", "TD-C-D", "TD-U-Db"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL",
+        "TD-C-D",
+        "TD-U-Db"
+      ]
     },
     {
       "id": 456,
@@ -9961,7 +10622,13 @@
         "CSS": 5322,
         "Makefile": 3354
       },
-      "tags": ["COM-C", "A", "TD-C-D", "ALL", "TD-U-Db"]
+      "tags": [
+        "COM-C",
+        "A",
+        "TD-C-D",
+        "ALL",
+        "TD-U-Db"
+      ]
     },
     {
       "id": 214,
@@ -10036,7 +10703,11 @@
         "CSS": 34523,
         "Dockerfile": 2228
       },
-      "tags": ["COM-C", "A", "ALL"]
+      "tags": [
+        "COM-C",
+        "A",
+        "ALL"
+      ]
     },
     {
       "id": 295,
@@ -10114,7 +10785,14 @@
         "XSLT": 7116,
         "HTML": 3739
       },
-      "tags": ["COM-C", "DO", "ALL", "SD-SOC", "Tracked", "TD-U-Msg"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "ALL",
+        "SD-SOC",
+        "Tracked",
+        "TD-U-Msg"
+      ]
     },
     {
       "id": 133,
@@ -10210,7 +10888,13 @@
         "Makefile": 2845,
         "Vim Snippet": 58
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 174,
@@ -10307,7 +10991,14 @@
         "Smarty": 376,
         "Vim Script": 154
       },
-      "tags": ["COM-C", "ALL", "IND-BFSI", "L&F", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "IND-BFSI",
+        "L&F",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 175,
@@ -10385,7 +11076,13 @@
         "Roff": 555,
         "Batchfile": 144
       },
-      "tags": ["COM-C", "DO", "ALL", "TD-C-DA", "Tracked"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "ALL",
+        "TD-C-DA",
+        "Tracked"
+      ]
     },
     {
       "id": 196,
@@ -10462,7 +11159,13 @@
         "Shell": 260,
         "Batchfile": 258
       },
-      "tags": ["COM-C", "ALL", "DA", "Tracked", "TD-U-Bln"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "DA",
+        "Tracked",
+        "TD-U-Bln"
+      ]
     },
     {
       "id": 211,
@@ -10537,7 +11240,13 @@
         "Just": 3354,
         "JavaScript": 1714
       },
-      "tags": ["COM-C", "ALL", "DA", "Tracked", "TD-U-Bln"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "DA",
+        "Tracked",
+        "TD-U-Bln"
+      ]
     },
     {
       "id": 245,
@@ -10610,7 +11319,13 @@
         "Makefile": 16766,
         "Dockerfile": 8839
       },
-      "tags": ["COM-C", "ALL", "DA", "Tracked", "TD-U-Bln"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "DA",
+        "Tracked",
+        "TD-U-Bln"
+      ]
     },
     {
       "id": 248,
@@ -10699,7 +11414,15 @@
         "Brainfuck": 54,
         "Ruby": 16
       },
-      "tags": ["COM-C", "DO", "ALL", "TD-C-WA", "TD-U-ApD", "TD-U-W", "Tracked"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "ALL",
+        "TD-C-WA",
+        "TD-U-ApD",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 442,
@@ -10777,7 +11500,12 @@
         "Cython": 3635,
         "Jsonnet": 937
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 443,
@@ -10849,7 +11577,12 @@
         "Dockerfile": 7577,
         "Makefile": 2748
       },
-      "tags": ["COM-C", "ALL", "L&F", "TD-U-AI/ML"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F",
+        "TD-U-AI/ML"
+      ]
     },
     {
       "id": 448,
@@ -10925,7 +11658,14 @@
         "Jinja": 2632,
         "Makefile": 2073
       },
-      "tags": ["COM-C", "ALL", "DA", "TD-C-DA", "Tracked", "TD-U-Bln"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "DA",
+        "TD-C-DA",
+        "Tracked",
+        "TD-U-Bln"
+      ]
     },
     {
       "id": 449,
@@ -10998,7 +11738,14 @@
         "Shell": 7232,
         "Dockerfile": 3129
       },
-      "tags": ["COM-C", "ALL", "DA", "TD-C-DA", "Tracked", "TD-U-Bln"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "DA",
+        "TD-C-DA",
+        "Tracked",
+        "TD-U-Bln"
+      ]
     },
     {
       "id": 451,
@@ -11071,7 +11818,15 @@
         "Batchfile": 8246,
         "HTML": 2422
       },
-      "tags": ["COM-F", "DO", "ALL", "TD-C-WA", "TD-U-ApD", "TD-U-W", "Tracked"]
+      "tags": [
+        "COM-F",
+        "DO",
+        "ALL",
+        "TD-C-WA",
+        "TD-U-ApD",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 452,
@@ -11155,7 +11910,14 @@
         "Batchfile": 1023,
         "Dockerfile": 210
       },
-      "tags": ["DO", "ALL", "TD-C-WA", "TD-U-ApD", "TD-U-W", "Tracked"]
+      "tags": [
+        "DO",
+        "ALL",
+        "TD-C-WA",
+        "TD-U-ApD",
+        "TD-U-W",
+        "Tracked"
+      ]
     },
     {
       "id": 457,
@@ -11242,7 +12004,12 @@
         "XSLT": 6024,
         "Dockerfile": 1030
       },
-      "tags": ["COM-F", "ALL", "DA", "TD-C-DA"]
+      "tags": [
+        "COM-F",
+        "ALL",
+        "DA",
+        "TD-C-DA"
+      ]
     },
     {
       "id": 458,
@@ -11324,7 +12091,13 @@
         "HTML": 1398,
         "HCL": 842
       },
-      "tags": ["COM-F", "DO", "ALL", "TD-C-D", "TD-U-Db"]
+      "tags": [
+        "COM-F",
+        "DO",
+        "ALL",
+        "TD-C-D",
+        "TD-U-Db"
+      ]
     },
     {
       "id": 473,
@@ -11396,7 +12169,14 @@
         "Shell": 4736,
         "Dockerfile": 341
       },
-      "tags": ["COM-C", "ALL", "SD-AS", "S", "TD-U-AI/ML", "Tracked"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "SD-AS",
+        "S",
+        "TD-U-AI/ML",
+        "Tracked"
+      ]
     },
     {
       "id": 462,
@@ -11482,7 +12262,11 @@
         "TLA": 14997,
         "Dockerfile": 4613
       },
-      "tags": ["COM-C", "ALL", "L&F"]
+      "tags": [
+        "COM-C",
+        "ALL",
+        "L&F"
+      ]
     },
     {
       "id": 465,
@@ -11554,7 +12338,10 @@
         "Kotlin": 29831,
         "HTML": 773
       },
-      "tags": ["L&F", "Untracked"]
+      "tags": [
+        "L&F",
+        "Untracked"
+      ]
     },
     {
       "id": 464,
@@ -11629,7 +12416,10 @@
         "Shell": 832,
         "Lua": 509
       },
-      "tags": ["L&F", "Untracked"]
+      "tags": [
+        "L&F",
+        "Untracked"
+      ]
     },
     {
       "id": 463,
@@ -11702,7 +12492,10 @@
         "Dockerfile": 4410,
         "JavaScript": 303
       },
-      "tags": ["L&F", "Untracked"]
+      "tags": [
+        "L&F",
+        "Untracked"
+      ]
     },
     {
       "id": 460,
@@ -11777,7 +12570,10 @@
         "Ruby": 7007,
         "Shell": 213
       },
-      "tags": ["L&F", "Untracked"]
+      "tags": [
+        "L&F",
+        "Untracked"
+      ]
     },
     {
       "id": 459,
@@ -11851,7 +12647,10 @@
         "Shell": 496,
         "HTML": 172
       },
-      "tags": ["L&F", "Untracked"]
+      "tags": [
+        "L&F",
+        "Untracked"
+      ]
     },
     {
       "id": 475,
@@ -11926,7 +12725,10 @@
         "Groovy": 5230,
         "Kotlin": 2400
       },
-      "tags": ["ALL", "Untracked"]
+      "tags": [
+        "IND-ALL",
+        "Untracked"
+      ]
     },
     {
       "id": 461,
@@ -12000,7 +12802,14 @@
         "Jupyter Notebook": 22983,
         "Dockerfile": 637
       },
-      "tags": ["COM-C", "A", "IND-CyS", "TD-C-WA", "TD-U-AI/ML", "Untracked"]
+      "tags": [
+        "COM-C",
+        "A",
+        "IND-CyS",
+        "TD-C-WA",
+        "TD-U-AI/ML",
+        "Untracked"
+      ]
     },
     {
       "id": 483,
@@ -12072,7 +12881,11 @@
         "Shell": 32945,
         "Makefile": 7785
       },
-      "tags": ["COM - C", "IND-ALL", "S"]
+      "tags": [
+        "COM - C",
+        "IND-ALL",
+        "S"
+      ]
     },
     {
       "id": 486,
@@ -12145,7 +12958,11 @@
         "Dockerfile": 330,
         "Shell": 265
       },
-      "tags": ["COM - C", "IND-ALL", "L&F"]
+      "tags": [
+        "COM - C",
+        "IND-ALL",
+        "L&F"
+      ]
     },
     {
       "id": 485,
@@ -12220,7 +13037,11 @@
         "Dockerfile": 2121,
         "Makefile": 1606
       },
-      "tags": ["COM - C", "A", "IND-ALL"]
+      "tags": [
+        "COM - C",
+        "A",
+        "IND-ALL"
+      ]
     },
     {
       "id": 484,
@@ -12300,7 +13121,11 @@
         "Java": 1080,
         "JavaScript": 13
       },
-      "tags": ["COM - C", "IND-ALL", "S"]
+      "tags": [
+        "COM - C",
+        "IND-ALL",
+        "S"
+      ]
     },
     {
       "id": 482,
@@ -12372,7 +13197,11 @@
         "Logos": 50545,
         "Shell": 1527
       },
-      "tags": ["COM - C", "A", "IND-ALL"]
+      "tags": [
+        "COM - C",
+        "A",
+        "IND-ALL"
+      ]
     },
     {
       "id": 478,
@@ -12451,9 +13280,16 @@
         "JavaSCript": 4582,
         "CSS": 2209,
         "Mustache": 1066,
-        "HTML": 895 
+        "HTML": 895
       },
-      "tags": ["COM-C", "DO", "IND-ALL", "TD-C-DA", "TD-U-ApD", "Tracked"]
+      "tags": [
+        "COM-C",
+        "DO",
+        "IND-ALL",
+        "TD-C-DA",
+        "TD-U-ApD",
+        "Tracked"
+      ]
     },
     {
       "id": 479,
@@ -12526,7 +13362,14 @@
         "Dockerfile": 1907,
         "Shell": 1737
       },
-      "tags": ["COM-C", "S", "IND-ALL", "SD-AS", "SD-SRM", "Tracked"]
+      "tags": [
+        "COM-C",
+        "S",
+        "IND-ALL",
+        "SD-AS",
+        "SD-SRM",
+        "Tracked"
+      ]
     },
     {
       "id": 480,
@@ -12601,7 +13444,12 @@
         "Shell": 4162,
         "HTML": 386
       },
-      "tags": ["COM-C", "L&F", "IND-ALL", "Tracked"]
+      "tags": [
+        "COM-C",
+        "L&F",
+        "IND-ALL",
+        "Tracked"
+      ]
     },
     {
       "id": 128,
@@ -12675,7 +13523,14 @@
         "Shell": 1499,
         "JavaScript": 735
       },
-      "tags": ["COM-F", "COM-F-OpenSSF", "S", "IND-CyS", "SD-SRM", "Tracked"]
+      "tags": [
+        "COM-F",
+        "COM-F-OpenSSF",
+        "S",
+        "IND-CyS",
+        "SD-SRM",
+        "Tracked"
+      ]
     },
     {
       "id": 481,
@@ -12748,7 +13603,14 @@
         "Shell": 3720,
         "Makefile": 2467
       },
-      "tags": ["COM-F", "COM-F-OpenSSF", "S", "IND-CyS", "SD-SRM", "Tracked"]
+      "tags": [
+        "COM-F",
+        "COM-F-OpenSSF",
+        "S",
+        "IND-CyS",
+        "SD-SRM",
+        "Tracked"
+      ]
     }
   ]
 }

--- a/projects/project-metadata.json
+++ b/projects/project-metadata.json
@@ -12373,6 +12373,382 @@
         "Shell": 1527
       },
       "tags": ["COM - C", "A", "IND-ALL"]
+    },
+    {
+      "id": 478,
+      "bes_tracking_id": 478,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/478",
+      "name": "argo-cd",
+      "full_name": "Be-Secure/argo-cd",
+      "description": "Declarative Continuous Deployment for Kubernetes",
+      "bes_technology_stack": "DO",
+      "watchers_count": 0,
+      "forks_count": 0,
+      "stargazers_count": 0,
+      "size": 89513,
+      "open_issues": 0,
+      "created_at": "2024-03-14T05:21:45Z",
+      "updated_at": "2024-02-15T14:49:24Z",
+      "pushed_at": "2024-02-16T05:58:03Z",
+      "git_url": "git://github.com/Be-Secure/argo-cd.git",
+      "clone_url": "https://github.com/Be-Secure/argo-cd.git",
+      "html_url": "https://github.com/Be-Secure/argo-cd",
+      "homepage": "https://argo-cd.readthedocs.io",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/argoproj/argo-cd",
+        "main_bes_url": "https://github.com/Be-Secure/argo-cd",
+        "all_projects": [
+          {
+            "id": 120896210,
+            "name": "argoproj/argo-cd",
+            "url": "https://github.com/argoproj/argo-cd"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 757251575,
+            "name": "Be-Secure/argo-cd",
+            "url": "https://github.com/Be-Secure/argo-cd"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Go": 5755713,
+        "TypeScript": 1108157,
+        "Lua": 104995,
+        "SCSS": 84810,
+        "Shell": 49417,
+        "Makefile": 24089,
+        "Dockerfile": 14969,
+        "Procfile": 9393,
+        "JavaSCript": 4582,
+        "CSS": 2209,
+        "Mustache": 1066,
+        "HTML": 895 
+      },
+      "tags": ["COM-C", "DO", "IND-ALL", "TD-C-DA", "TD-U-ApD", "Tracked"]
+    },
+    {
+      "id": 479,
+      "bes_tracking_id": 479,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/479",
+      "name": "sigstore",
+      "full_name": "Be-Secure/sigstore",
+      "description": "Common go library shared across sigstore services and clients",
+      "bes_technology_stack": "S",
+      "watchers_count": 0,
+      "forks_count": 0,
+      "stargazers_count": 0,
+      "size": 3727,
+      "open_issues": 0,
+      "created_at": "2024-02-15T07:25:30Z",
+      "updated_at": "2024-02-15T15:44:37Z",
+      "pushed_at": "2024-02-16T06:36:54Z",
+      "git_url": "git://github.com/Be-Secure/sigstore.git",
+      "clone_url": "https://github.com/Be-Secure/sigstore.git",
+      "html_url": "https://github.com/Be-Secure/sigstore",
+      "homepage": "https://sigstore.dev",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/sigstore/sigstore",
+        "main_bes_url": "https://github.com/Be-Secure/sigstore",
+        "all_projects": [
+          {
+            "id": 338633268,
+            "name": "sigstore/sigstore",
+            "url": "https://github.com/sigstore/sigstore"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 757884429,
+            "name": "Be-Secure/sigstore",
+            "url": "https://github.com/Be-Secure/sigstore"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Go": 515097,
+        "Makefile": 2948,
+        "Dockerfile": 1907,
+        "Shell": 1737
+      },
+      "tags": ["COM-C", "S", "IND-ALL", "SD-AS", "SD-SRM", "Tracked"]
+    },
+    {
+      "id": 480,
+      "bes_tracking_id": 480,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/480",
+      "name": "lettuce",
+      "full_name": "Be-Secure/lettuce",
+      "description": "Advanced Java Redis client for thread-safe sync, async, and reactive usage. Supports Cluster, Sentinel, Pipelining, and codecs.",
+      "bes_technology_stack": "L&F",
+      "watchers_count": 0,
+      "forks_count": 0,
+      "stargazers_count": 0,
+      "size": 20370,
+      "open_issues": 0,
+      "created_at": "2023-06-07T06:56:01Z",
+      "updated_at": "2023-06-07T06:57:39Z",
+      "pushed_at": "2024-02-16T08:17:57Z",
+      "git_url": "git://github.com/Be-Secure/lettuce.git",
+      "clone_url": "https://github.com/Be-Secure/lettuce.git",
+      "html_url": "https://github.com/Be-Secure/lettuce",
+      "homepage": "https://lettuce.io",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/lettuce-io/lettuce-core",
+        "main_bes_url": "https://github.com/Be-Secure/lettuce",
+        "all_projects": [
+          {
+            "id": 19641638,
+            "name": "lettuce-io/lettuce-core",
+            "url": "https://github.com/lettuce-io/lettuce-core"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 650481055,
+            "name": "Be-Secure/lettuce",
+            "url": "https://github.com/Be-Secure/lettuce"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Java": 6539869,
+        "Kotlin": 275821,
+        "CSS": 41627,
+        "Makefile": 15409,
+        "Shell": 4162,
+        "HTML": 386
+      },
+      "tags": ["COM-C", "L&F", "IND-ALL", "Tracked"]
+    },
+    {
+      "id": 128,
+      "bes_tracking_id": 128,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/128",
+      "name": "scorecard",
+      "full_name": "Be-Secure/scorecard",
+      "description": "OpenSSF Scorecard - Security health metrics for Open Source",
+      "bes_technology_stack": "S",
+      "watchers_count": 0,
+      "forks_count": 0,
+      "stargazers_count": 0,
+      "size": 199036,
+      "open_issues": 0,
+      "created_at": "2020-12-17T03:37:30Z",
+      "updated_at": "2024-02-15T10:34:23Z",
+      "pushed_at": "2024-02-16T06:49:46Z",
+      "git_url": "git://github.com/Be-Secure/scorecard.git",
+      "clone_url": "https://github.com/Be-Secure/scorecard.git",
+      "html_url": "https://github.com/Be-Secure/scorecard",
+      "homepage": "https://scorecard.dev",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/ossf/scorecard",
+        "main_bes_url": "https://github.com/Be-Secure/scorecard",
+        "all_projects": [
+          {
+            "id": 302670797,
+            "name": "ossf/scorecard",
+            "url": "https://github.com/ossf/scorecard"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 322170920,
+            "name": "Be-Secure/scorecard",
+            "url": "https://github.com/Be-Secure/scorecard"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Go": 1929157,
+        "Makefile": 20816,
+        "Dockerfile": 9180,
+        "Shell": 1499,
+        "JavaScript": 735
+      },
+      "tags": ["COM-F", "COM-F-OpenSSF", "S", "IND-CyS", "SD-SRM", "Tracked"]
+    },
+    {
+      "id": 481,
+      "bes_tracking_id": 481,
+      "issue_url": "https://github.com/Be-Secure/Be-Secure/issues/481",
+      "name": "criticality_score",
+      "full_name": "Be-Secure/criticality_score",
+      "description": "Gives criticality score for an open source project",
+      "bes_technology_stack": "S",
+      "watchers_count": 0,
+      "forks_count": 2,
+      "stargazers_count": 0,
+      "size": 1264,
+      "open_issues": 0,
+      "created_at": "2021-09-16T03:29:43Z",
+      "updated_at": "2022-09-15T08:44:05Z",
+      "pushed_at": "2024-02-16T05:24:47Z",
+      "git_url": "git://github.com/Be-Secure/criticality_score.git",
+      "clone_url": "https://github.com/Be-Secure/criticality_score.git",
+      "html_url": "https://github.com/Be-Secure/criticality_score",
+      "homepage": "",
+      "owner": {
+        "login": "Be-Secure",
+        "id": 44028837,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0MDI4ODM3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/44028837?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Be-Secure",
+        "html_url": "https://github.com/Be-Secure",
+        "followers_url": "https://api.github.com/users/Be-Secure/followers",
+        "following_url": "https://api.github.com/users/Be-Secure/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Be-Secure/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Be-Secure/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Be-Secure/subscriptions",
+        "organizations_url": "https://api.github.com/users/Be-Secure/orgs",
+        "repos_url": "https://api.github.com/users/Be-Secure/repos",
+        "events_url": "https://api.github.com/users/Be-Secure/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Be-Secure/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "project_repos": {
+        "main_github_url": "https://github.com/ossf/criticality_score",
+        "main_bes_url": "https://github.com/Be-Secure/criticality_score",
+        "all_projects": [
+          {
+            "id": 313674213,
+            "name": "ossf/criticality_score",
+            "url": "https://github.com/ossf/criticality_score"
+          }
+        ],
+        "all_bes_repos": [
+          {
+            "id": 407006100,
+            "name": "Be-Secure/criticality_score",
+            "url": "https://github.com/Be-Secure/criticality_score"
+          }
+        ]
+      },
+      "license": {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "spdx_id": "Apache-2.0",
+        "url": "https://api.github.com/licenses/apache-2.0",
+        "node_id": "MDc6TGljZW5zZTI="
+      },
+      "language": {
+        "Go": 287800,
+        "Dockerfile": 4550,
+        "Shell": 3720,
+        "Makefile": 2467
+      },
+      "tags": ["COM-F", "COM-F-OpenSSF", "S", "IND-CyS", "SD-SRM", "Tracked"]
     }
   ]
 }

--- a/projects/project-version/128-scorecard-Versiondetails.json
+++ b/projects/project-version/128-scorecard-Versiondetails.json
@@ -1,0 +1,16 @@
+[
+    {
+      "version": "v4.8.0",
+      "release_date": "18-Oct-2022",
+      "criticality_score": 0.37838,
+      "scorecard": 5.2,
+      "cve_details": "Not Available"
+    },
+    {
+        "version": "v4.13.1",
+        "release_date": "21-Oct-2023",
+        "criticality_score": 0.41172,
+        "scorecard": 6.2,
+        "cve_details": "Not Available"
+    }
+  ]

--- a/projects/project-version/252-rosdistro-Versiondetails.json
+++ b/projects/project-version/252-rosdistro-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "humble-2022-05-23",
         "release_date": "23-May-2022",
-        "criticality_score": 0.54543,
+        "criticality_score": 0.54507,
         "scorecard": 5.4,
         "cve_details": "Not Available"
     }

--- a/projects/project-version/259-mythril-Versiondetails.json
+++ b/projects/project-version/259-mythril-Versiondetails.json
@@ -10,7 +10,7 @@
         "version": "v0.23.25",
         "release_date": "17-Aug-2023",
         "criticality_score": 0.38481,
-        "scorecard": 4.2,
+        "scorecard": 4.6,
         "cve_details": "Not Available"
     },
     {
@@ -18,6 +18,13 @@
         "release_date": "18-Dec-2023",
         "criticality_score": 0.37541,
         "scorecard": 4.6,
+        "cve_details": "Not Available"
+    },
+    {
+        "version": "v0.23.12",
+        "release_date": "18-Dec-2023",
+        "criticality_score": 0.35708,
+        "scorecard": 3.7,
         "cve_details": "Not Available"
     }
 ]

--- a/projects/project-version/464-spring-data-redis-Versiondetails.json
+++ b/projects/project-version/464-spring-data-redis-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "3.2.0",
         "release_date": "17-Nov-2023",
-        "criticality_score": "Not Available",
+        "criticality_score": 0.39051,
         "scorecard": "Not Available",
         "cve_details": "Not Available"
     }

--- a/projects/project-version/465-spring-kafka-Versiondetails.json
+++ b/projects/project-version/465-spring-kafka-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "v3.1.0",
         "release_date": "20-Nov-2023",
-        "criticality_score": "Not Available",
+        "criticality_score": 0.4314,
         "scorecard": "Not Available",
         "cve_details": "Not Available"
     }

--- a/projects/project-version/467-modelscan-Versiondetails.json
+++ b/projects/project-version/467-modelscan-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "v0.3.0",
         "release_date": "25-Oct-2023",
-        "criticality_score": "Not Available",
+        "criticality_score": 0.22319,
         "scorecard": "Not Available",
         "cve_details": "Not Available"
     }

--- a/projects/project-version/468-model-analysis-Versiondetails.json
+++ b/projects/project-version/468-model-analysis-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "v0.45.0",
         "release_date": "14-Aug-2023",
-        "criticality_score": "Not Available",
+        "criticality_score": 0.30053,
         "scorecard": "Not Available",
         "cve_details": "Not Available"
     }

--- a/projects/project-version/473-DecodingTrust-Versiondetails.json
+++ b/projects/project-version/473-DecodingTrust-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "alpha",
         "release_date": "Not Available",
-        "criticality_score": "Not Available",
+        "criticality_score": 0.20087,
         "scorecard": 4.6,
         "cve_details": "Not Available"
     }

--- a/projects/project-version/475-newrelic-java-agent-Versiondetails.json
+++ b/projects/project-version/475-newrelic-java-agent-Versiondetails.json
@@ -2,7 +2,7 @@
     {
         "version": "v8.7.0",
         "release_date": "24-Oct-2023",
-        "criticality_score": "Not Available",
+        "criticality_score": 0.30017,
         "scorecard": 2.9,
         "cve_details": "Not Available"
     }

--- a/projects/project-version/478-argo-cd-Versiondetails.json
+++ b/projects/project-version/478-argo-cd-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+      "version": "v2.10.1",
+      "release_date": "14-Feb-2024",
+      "criticality_score": 0.49469,
+      "scorecard": 5.3,
+      "cve_details": "Not Available"
+    }
+  ]

--- a/projects/project-version/479-sigstore-Versiondetails.json
+++ b/projects/project-version/479-sigstore-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+      "version": "v1.8.1",
+      "release_date": "17-Jan-2024",
+      "criticality_score": 0.41468,
+      "scorecard": 4.5,
+      "cve_details": "Not Available"
+    }
+  ]

--- a/projects/project-version/480-lettuce-Versiondetails.json
+++ b/projects/project-version/480-lettuce-Versiondetails.json
@@ -1,0 +1,16 @@
+[
+    {
+      "version": "3.5.0.Final",
+      "release_date": "01-Jul-2016",
+      "criticality_score": 0.41880,
+      "scorecard": 4.6,
+      "cve_details": "Not Available"
+    },
+    {
+        "version": "6.3.1.RELEASE",
+        "release_date": "10-Jan-2024",
+        "criticality_score": 0.42810,
+        "scorecard": 5.7,
+        "cve_details": "Not Available"
+    }
+  ]

--- a/projects/project-version/481-criticality_score-Versiondetails.json
+++ b/projects/project-version/481-criticality_score-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+      "version": "v2.0.2",
+      "release_date": "28-Feb-2023",
+      "criticality_score": 0.34212,
+      "scorecard": 4.8,
+      "cve_details": "Not Available"
+    }
+  ]

--- a/projects/project-version/482-jackson-core-Versiondetails.json
+++ b/projects/project-version/482-jackson-core-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+        "version": "jackson-core-2.16.1",
+        "release_date": "23-Dec-2023",
+        "criticality_score": 0.40079,
+        "scorecard": 6.7,
+        "cve_details": "Not Available"
+    }
+]

--- a/projects/project-version/483-helm-Versiondetails.json
+++ b/projects/project-version/483-helm-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+        "version": "v3.6.3",
+        "release_date": "14-Jul-2021",
+        "criticality_score": 0.46074,
+        "scorecard": 4.7,
+        "cve_details": "Not Available"
+    }
+]

--- a/projects/project-version/484-istio-Versiondetails.json
+++ b/projects/project-version/484-istio-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+        "version": "1.20.3",
+        "release_date": "01-Feb-2024",
+        "criticality_score": 0.47104,
+        "scorecard": 6,
+        "cve_details": "Not Available"
+    }
+]

--- a/projects/project-version/485-k6-Versiondetails.json
+++ b/projects/project-version/485-k6-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+    {
+        "version": "v0.49.0",
+        "release_date": "29-Jan-2024",
+        "criticality_score": 0.42036,
+        "scorecard": 5,
+        "cve_details": "Not Available"
+    }
+]

--- a/projects/project-version/486-TypeScript-Versiondetails.json
+++ b/projects/project-version/486-TypeScript-Versiondetails.json
@@ -1,0 +1,9 @@
+[
+  {
+    "version": "v5.4-beta",
+    "release_date": "28-Jan-2024",
+    "criticality_score": 0.42757,
+    "scorecard": 5.9,
+    "cve_details": "Not Available"
+  }
+]


### PR DESCRIPTION
changed "bes_technology_stack" for security-analytics-export-tools, opstrace , codeclimate, dvc, mlem, terraform-provider-luminate from S to DO as suggested